### PR TITLE
Adjust to handle fixed indicated_compatibility_mode doctype property

### DIFF
--- a/html-api-debugger/html-api-integration.php
+++ b/html-api-debugger/html-api-integration.php
@@ -129,9 +129,14 @@ function get_tree( string $html, array $options ): array {
 					$doctype_name              = $doctype->name;
 					$doctype_public_identifier = $doctype->public_identifier;
 					$doctype_system_identifier = $doctype->system_identifier;
-					if ( $doctype->indicated_compatability_mode !== 'quirks' ) {
+					if (
+						( property_exists( $doctype, 'indicated_compatibility_mode' )
+							? $doctype->indicated_compatibility_mode
+							: $doctype->indicated_compatability_mode ) !== 'quirks'
+					) {
 						$compat_mode = 'CSS1Compat';
 					}
+
 					break;
 
 				case '#tag':
@@ -234,7 +239,11 @@ function get_tree( string $html, array $options ): array {
 				$doctype_name              = $doctype->name;
 				$doctype_public_identifier = $doctype->public_identifier;
 				$doctype_system_identifier = $doctype->system_identifier;
-				if ( $doctype->indicated_compatability_mode !== 'quirks' ) {
+				if (
+					( property_exists( $doctype, 'indicated_compatibility_mode' )
+						? $doctype->indicated_compatibility_mode
+						: $doctype->indicated_compatability_mode ) !== 'quirks'
+				) {
 					$compat_mode = 'CSS1Compat';
 				}
 

--- a/html-api-debugger/html-api-integration.php
+++ b/html-api-debugger/html-api-integration.php
@@ -136,7 +136,6 @@ function get_tree( string $html, array $options ): array {
 					) {
 						$compat_mode = 'CSS1Compat';
 					}
-
 					break;
 
 				case '#tag':

--- a/html-api-debugger/readme.txt
+++ b/html-api-debugger/readme.txt
@@ -17,6 +17,7 @@ Please file issues and pull requests on the [GitHub repository](https://github.c
 
 = 2.8 =
 * Silence _doing_it_wrong bookmark notices when providing from HTML context.
+* Adjust doctype info to account for typo fix.
 
 = 2.7 =
 * Preserve attribute value line breaks in tree views.


### PR DESCRIPTION
See https://github.com/WordPress/wordpress-develop/pull/9401.