### PR TITLE
[codex] Fix fragment tree depth tracking

### DIFF
--- a/html-api-debugger/html-api-integration.php
+++ b/html-api-debugger/html-api-integration.php
@@ -108,7 +108,8 @@ function get_tree( string $html, array $options ): array {
 		$cfacn->setAccessible( true );
 	}
 
-	$is_fragment_processor = false;
+	$is_fragment_processor  = false;
+	$processor_depth_offset = 0;
 
 	$compat_mode               = 'BackCompat';
 	$document_title            = null;
@@ -163,6 +164,9 @@ function get_tree( string $html, array $options ): array {
 			 * @disregard P1013
 			 */
 			$processor = $cfacn->invoke( $context_processor, $html );
+			if ( null !== $processor ) {
+				$processor_depth_offset = $processor->get_current_depth();
+			}
 		}
 
 		if ( ! isset( $processor ) ) {
@@ -190,13 +194,12 @@ function get_tree( string $html, array $options ): array {
 		'childNodes' => array(),
 	);
 
-	$cursor = array( 0 );
+	$cursor = array();
 
 	if ( $is_fragment_processor ) {
-		$tree   = array(
+		$tree = array(
 			'childNodes' => array(),
 		);
-		$cursor = array();
 	}
 
 	$context_node = isset( $context_processor )
@@ -220,18 +223,36 @@ function get_tree( string $html, array $options ): array {
 			break;
 		}
 
-		// Depth needs and adjustment because:
-		// - Nodes in a full tree are all placed under a document node.
-		// - Nodes in a fragment tree start at the root.
-		if ( \count( $cursor ) + 1 > $processor->get_current_depth() - ( $is_fragment_processor ? 1 : 0 ) ) {
+		$token_type = $processor->get_token_type();
+
+		/*
+		 * Fragment processors retain a synthetic HTML > context-node prefix in
+		 * their breadcrumbs. The debugger tree omits those nodes, so remove that
+		 * prefix before mapping the processor depth onto the local cursor.
+		 */
+		$processor_depth = $processor->get_current_depth();
+		if ( $processor_depth < $processor_depth_offset ) {
+			throw new Exception( 'Processor depth is shallower than the fragment context depth.' );
+		}
+
+		$token_depth = $processor_depth - $processor_depth_offset;
+		if ( '#doctype' === $token_type ) {
+			$token_parent_depth = 0;
+		} elseif ( '#tag' === $token_type && $processor->is_tag_closer() ) {
+			$token_parent_depth = $token_depth;
+		} else {
+			$token_parent_depth = max( 0, $token_depth - 1 );
+		}
+
+		$cursor_count = \count( $cursor );
+		while ( $cursor_count > $token_parent_depth ) {
 			array_pop( $cursor );
+			--$cursor_count;
 		}
 		$current = &$tree;
 		foreach ( $cursor as $path ) {
 			$current = &$current['childNodes'][ $path ];
 		}
-
-		$token_type = $processor->get_token_type();
 
 		switch ( $token_type ) {
 			case '#doctype':

--- a/html-api-debugger/readme.txt
+++ b/html-api-debugger/readme.txt
@@ -16,6 +16,7 @@ Please file issues and pull requests on the [GitHub repository](https://github.c
 == Changelog ==
 
 * Add "HTML5 Body" context button to allow setting default context.
+* Fix fragment tree depth so nodes following atomic elements (`textarea`, `script`, `style`) nest correctly to match the DOM tree.
 
 = 2.9 =
 * Fix implicit nullable parameter.

--- a/tests/html-api-integration-regression.php
+++ b/tests/html-api-integration-regression.php
@@ -1,0 +1,278 @@
+<?php
+/**
+ * Regression tests for the HTML API integration tree builder.
+ *
+ * Run with:
+ *
+ *     WP_CORE_DIR=/path/to/wordpress/src php tests/html-api-integration-regression.php
+ *
+ * @package HtmlApiDebugger
+ */
+
+// phpcs:disable
+// This standalone CLI harness intentionally defines minimal WordPress stubs and writes TAP-like output.
+error_reporting( E_ALL & ~E_DEPRECATED );
+
+if ( ! function_exists( '__' ) ) {
+	function __( $text, $domain = 'default' ) {
+		return $text;
+	}
+}
+
+if ( ! function_exists( '_doing_it_wrong' ) ) {
+	function _doing_it_wrong( $function_name, $message, $version ) {
+	}
+}
+
+if ( ! function_exists( 'wp_trigger_error' ) ) {
+	function wp_trigger_error( $function_name, $message, $error_level = E_USER_NOTICE ) {
+	}
+}
+
+if ( ! function_exists( 'add_filter' ) ) {
+	function add_filter( $hook_name, $callback, $priority = 10, $accepted_args = 1 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'remove_filter' ) ) {
+	function remove_filter( $hook_name, $callback, $priority = 10 ) {
+		return true;
+	}
+}
+
+if ( ! function_exists( 'apply_filters' ) ) {
+	function apply_filters( $hook_name, $value, ...$args ) {
+		return $value;
+	}
+}
+
+if ( ! function_exists( 'do_action' ) ) {
+	function do_action( $hook_name, ...$args ) {
+	}
+}
+
+$core_dir = getenv( 'WP_CORE_DIR' );
+if ( ! $core_dir ) {
+	fwrite( STDERR, "Set WP_CORE_DIR to a WordPress src checkout.\n" );
+	exit( 2 );
+}
+
+$core_dir    = rtrim( $core_dir, '/' );
+$include_dir = "{$core_dir}/wp-includes";
+
+if ( ! file_exists( "{$include_dir}/html-api/class-wp-html-processor.php" ) ) {
+	fwrite( STDERR, "WP_CORE_DIR must point to a WordPress src checkout containing wp-includes/html-api.\n" );
+	exit( 2 );
+}
+
+if ( ! class_exists( 'WP_HTML_Processor' ) ) {
+	require "{$include_dir}/class-wp-token-map.php";
+
+	foreach (
+		array(
+			'class-wp-html-text-replacement.php',
+			'class-wp-html-span.php',
+			'class-wp-html-attribute-token.php',
+			'class-wp-html-doctype-info.php',
+			'class-wp-html-unsupported-exception.php',
+			'class-wp-html-decoder.php',
+			'class-wp-html-tag-processor.php',
+			'class-wp-html-token.php',
+			'class-wp-html-stack-event.php',
+			'class-wp-html-open-elements.php',
+			'class-wp-html-active-formatting-elements.php',
+			'class-wp-html-processor-state.php',
+			'class-wp-html-processor.php',
+		) as $file
+	) {
+		require "{$include_dir}/html-api/{$file}";
+	}
+}
+
+require dirname( __DIR__ ) . '/html-api-debugger/html-api-integration.php';
+
+/**
+ * Convert a debugger tree into stable text lines.
+ *
+ * @param array $node  Tree node.
+ * @param int   $depth Current output depth.
+ * @return string[] Tree lines.
+ */
+function html_api_debugger_test_tree_lines( array $node, int $depth = 0 ): array {
+	$lines = array();
+
+	foreach ( $node['childNodes'] ?? array() as $child ) {
+		if ( ! empty( $child['_closer'] ) ) {
+			continue;
+		}
+
+		$line = str_repeat( '  ', $depth ) . $child['nodeName'];
+		if ( isset( $child['nodeValue'] ) ) {
+			$value = str_replace( array( "\r", "\n" ), array( '\\r', '\\n' ), $child['nodeValue'] );
+			$line .= ':' . $value;
+		}
+
+		$lines[] = $line;
+		array_push( $lines, ...html_api_debugger_test_tree_lines( $child, $depth + 1 ) );
+	}
+
+	return $lines;
+}
+
+/**
+ * Assert a single debugger tree shape.
+ *
+ * @param string      $label        Test label.
+ * @param string      $html         Input HTML.
+ * @param string|null $context_html Optional fragment context.
+ * @param string[]    $expected     Expected tree lines.
+ */
+function html_api_debugger_assert_tree( string $label, string $html, ?string $context_html, array $expected ): void {
+	$result = HTML_API_Debugger\HTML_API_Integration\get_tree(
+		$html,
+		array(
+			'context_html' => $context_html,
+			'selector' => null,
+		)
+	);
+
+	$actual = html_api_debugger_test_tree_lines( $result['tree'] );
+	if ( $actual === $expected ) {
+		echo "ok - {$label}\n";
+		return;
+	}
+
+	echo "not ok - {$label}\n";
+	echo "Expected:\n";
+	echo implode( "\n", $expected ), "\n";
+	echo "Actual:\n";
+	echo implode( "\n", $actual ), "\n";
+	exit( 1 );
+}
+
+$body_context = '<!DOCTYPE html><body>';
+
+html_api_debugger_assert_tree(
+	'full parser preserves document nesting',
+	'<div><p>a</p>b</div>c',
+	null,
+	array(
+		'HTML',
+		'  HEAD',
+		'  BODY',
+		'    DIV',
+		'      P',
+		'        #text:a',
+		'      #text:b',
+		'    #text:c',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'body fragment keeps atomic element siblings at root',
+	'<textarea>x</textarea><after>',
+	$body_context,
+	array(
+		'TEXTAREA',
+		'  #text:x',
+		'AFTER',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'body fragment keeps adjacent atomic elements as siblings',
+	'<textarea>X</textarea><textarea>Y</textarea>z',
+	$body_context,
+	array(
+		'TEXTAREA',
+		'  #text:X',
+		'TEXTAREA',
+		'  #text:Y',
+		'#text:z',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'body fragment handles implied paragraph closer',
+	'<p>one<div>two</div>',
+	$body_context,
+	array(
+		'P',
+		'  #text:one',
+		'DIV',
+		'  #text:two',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'list fragment handles implied list item closer',
+	'<ul><li>one<li>two</ul>',
+	$body_context,
+	array(
+		'UL',
+		'  LI',
+		'    #text:one',
+		'  LI',
+		'    #text:two',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'div context strips fragment context prefix',
+	'<p>a</p>b',
+	'<!DOCTYPE html><body><main><div>',
+	array(
+		'P',
+		'  #text:a',
+		'#text:b',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'table context preserves implied table descendants',
+	'<tr><td>a</td></tr>',
+	'<!DOCTYPE html><body><table>',
+	array(
+		'TBODY',
+		'  TR',
+		'    TD',
+		'      #text:a',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'table row context handles implied table cell closer',
+	'<td>one<td>two',
+	'<!DOCTYPE html><body><table><tbody><tr>',
+	array(
+		'TD',
+		'  #text:one',
+		'TD',
+		'  #text:two',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'select context handles implied option closer',
+	'<option>one<option>two',
+	'<!DOCTYPE html><body><select>',
+	array(
+		'OPTION',
+		'  #text:one',
+		'OPTION',
+		'  #text:two',
+	)
+);
+
+html_api_debugger_assert_tree(
+	'template context uses template insertion mode without leaking context node',
+	'<p>a</p>',
+	'<!DOCTYPE html><body><template>',
+	array(
+		'P',
+		'  #text:a',
+	)
+);
+
+echo "All HTML API integration regression tests passed.\n";


### PR DESCRIPTION
## Summary

Fixes debugger tree construction for HTML API fragment parsing by mapping processor depth to the debugger tree relative to the fragment processor's synthetic context prefix.

## Root Cause

Fragment processors retain an implicit `HTML > context-node` prefix in their reported depth and breadcrumbs, while the debugger tree intentionally omits those context ancestors. The previous cursor logic subtracted a hard-coded `1`, which could leave the local tree cursor inside a root-level fragment element. Atomic/self-contained elements such as `TEXTAREA`, `SCRIPT`, and `STYLE` made this visible because their contents are surfaced through `get_modifiable_text()` rather than a normal child-token traversal.

## Changes

- Capture the fragment processor's starting depth after `create_fragment_at_current_node()`.
- Normalize token depth against that fragment prefix before updating the local tree cursor.
- Treat closing tags according to the HTML API's already-popped closer depth.
- Throw if processor depth ever underflows the captured fragment prefix instead of silently flattening nodes.
- Add a standalone regression harness covering full parser output, body fragments, atomic siblings, implied closers, and div/table/select/template contexts.

## Validation

- `WP_CORE_DIR=/Users/jonsurrell/a8c/wordpress-develop/trunk/src php tests/html-api-integration-regression.php`
- `vendor/bin/phpcs --standard=phpcs.xml html-api-debugger/html-api-integration.php tests/html-api-integration-regression.php`
- `git diff --check`

## Review

Reviewed by a 3-agent adversarial panel. First pass was 2 APPROVE / 1 REJECT; after adding the regression harness and depth-underflow guard, the second pass was 3 APPROVE.
