### PR TITLE
Remove dead #doctype depth-mapping branch

### DIFF
--- a/html-api-debugger/html-api-integration.php
+++ b/html-api-debugger/html-api-integration.php
@@ -236,9 +236,7 @@ function get_tree( string $html, array $options ): array {
 		}
 
 		$token_depth = $processor_depth - $processor_depth_offset;
-		if ( '#doctype' === $token_type ) {
-			$token_parent_depth = 0;
-		} elseif ( '#tag' === $token_type && $processor->is_tag_closer() ) {
+		if ( '#tag' === $token_type && $processor->is_tag_closer() ) {
 			$token_parent_depth = $token_depth;
 		} else {
 			$token_parent_depth = max( 0, $token_depth - 1 );


### PR DESCRIPTION
## What

Deletes the `#doctype` branch from the depth-mapping `if/elseif/else` in `html-api-debugger/html-api-integration.php` (the block that computes `$token_parent_depth`).

Before:

```php
$token_depth = $processor_depth - $processor_depth_offset;
if ( '#doctype' === $token_type ) {
    $token_parent_depth = 0;
} elseif ( '#tag' === $token_type && $processor->is_tag_closer() ) {
    $token_parent_depth = $token_depth;
} else {
    $token_parent_depth = max( 0, $token_depth - 1 );
}
```

After:

```php
$token_depth = $processor_depth - $processor_depth_offset;
if ( '#tag' === $token_type && $processor->is_tag_closer() ) {
    $token_parent_depth = $token_depth;
} else {
    $token_parent_depth = max( 0, $token_depth - 1 );
}
```

## Why

The `#doctype` branch can never produce a result different from the `else` fallback:

- A `#doctype` token only surfaces at document start, where `depth == 1`, so the `else` branch yields `max(0, 1-1) == 0` — identical to the explicit `0`.
- Mid-stream doctypes are not emitted as tokens.
- In fragment mode a depth-1 doctype hits the underflow `throw` above this block first.

It's dead as a distinct path. The separate `switch ( $token_type ) { case '#doctype': ... }` block lower in the same function (which renders doctype info into the tree) is **untouched**.

## Verification

- `php -l html-api-debugger/html-api-integration.php` → no syntax errors.
- `tests/html-api-integration-regression.php` → 10 ok, exit 0, unchanged from baseline. The "full parser preserves document nesting" case covers document structure.
- No change to any rendered tree.

## Heads-up: rebase needed if merged second

A sibling PR (branch `followup/minor-nits`, Follow-up 3) edits the SAME file ~3 lines above this change — it adds a comment to the underflow `throw` at lines 234–236. Whichever of the two PRs merges second will need a trivial rebase.

https://claude.ai/code/session_0199VgayzxnEG2UkQVzFW3gJ