### PR TITLE
[codex] Add URL state for debugger options

### DIFF
--- a/html-api-debugger/main.mjs
+++ b/html-api-debugger/main.mjs
@@ -130,11 +130,15 @@ let mutationObserver = null;
 
 const createStore = /** @type {typeof I.store<Store>} */ ( I.store );
 
+const HTML_OPTIONS_PARAM = 'html-opts';
+
 const BOOLEAN_CONFIGURATION_OPTIONS = /** @type {const} */ ( [
-	[ 'C', 'showClosers' ],
-	[ 'I', 'showInvisible' ],
-	[ 'V', 'showVirtual' ],
+	[ 'C', 'c', 'showClosers' ],
+	[ 'I', 'i', 'showInvisible' ],
+	[ 'V', 'v', 'showVirtual' ],
 ] );
+
+const booleanConfigurationOverrides = getInitialBooleanConfigurationOverrides();
 
 /** @type {Store} */
 const store = createStore( NS, {
@@ -282,10 +286,7 @@ const store = createStore( NS, {
 			if ( store.state.selector ) {
 				searchParams.set( 'selector', store.state.selector );
 			}
-			const options = getEnabledOptions();
-			if ( options ) {
-				searchParams.set( 'options', options );
-			}
+			searchParams.set( HTML_OPTIONS_PARAM, getResolvedHtmlOptions() );
 			const base = '/wp-admin/admin.php';
 			const u = new URL(
 				'https://playground.wordpress.net/?plugin=html-api-debugger',
@@ -547,14 +548,14 @@ const store = createStore( NS, {
 				shouldReplace = true;
 			}
 		}
-		const options = getEnabledOptions();
-		if ( options ) {
-			if ( u.searchParams.get( 'options' ) !== options ) {
-				u.searchParams.set( 'options', options );
+		const htmlOptions = getExplicitHtmlOptions();
+		if ( htmlOptions ) {
+			if ( u.searchParams.get( HTML_OPTIONS_PARAM ) !== htmlOptions ) {
+				u.searchParams.set( HTML_OPTIONS_PARAM, htmlOptions );
 				shouldReplace = true;
 			}
-		} else if ( u.searchParams.has( 'options' ) ) {
-			u.searchParams.delete( 'options' );
+		} else if ( u.searchParams.has( HTML_OPTIONS_PARAM ) ) {
+			u.searchParams.delete( HTML_OPTIONS_PARAM );
 			shouldReplace = true;
 		}
 		if ( shouldReplace ) {
@@ -819,27 +820,83 @@ const store = createStore( NS, {
  * @returns {boolean}
  */
 function getInitialBooleanConfigurationValue( option ) {
-	const options = new URL( document.location.href ).searchParams.get(
-		'options',
-	);
-	if ( ! options ) {
-		return false;
+	const override = booleanConfigurationOverrides[ option ];
+	if ( override !== null ) {
+		return override;
 	}
-	return BOOLEAN_CONFIGURATION_OPTIONS.some(
-		( [ code, optionName ] ) =>
-			optionName === option && options.includes( code ),
-	);
+	return getStoredBooleanConfigurationValue( option );
+}
+
+/**
+ * @returns {Record<BooleanConfigurationOption, boolean|null>}
+ */
+function getInitialBooleanConfigurationOverrides() {
+	const overrides =
+		/** @type {Record<BooleanConfigurationOption, boolean|null>} */ ( {
+			showClosers: null,
+			showInvisible: null,
+			showVirtual: null,
+		} );
+	const searchParams = new URL( document.location.href ).searchParams;
+	if ( ! searchParams.has( HTML_OPTIONS_PARAM ) ) {
+		return overrides;
+	}
+
+	const htmlOptions = searchParams.get( HTML_OPTIONS_PARAM ) ?? '';
+	for ( const value of htmlOptions ) {
+		for ( const [
+			enabledCode,
+			disabledCode,
+			option,
+		] of BOOLEAN_CONFIGURATION_OPTIONS ) {
+			if ( value === enabledCode ) {
+				overrides[ option ] = true;
+			} else if ( value === disabledCode ) {
+				overrides[ option ] = false;
+			}
+		}
+	}
+	return overrides;
+}
+
+/** @param {BooleanConfigurationOption} option */
+function getStoredBooleanConfigurationValue( option ) {
+	return Boolean( localStorage.getItem( `${ NS }-${ option }` ) );
 }
 
 /** @returns {string} */
-function getEnabledOptions() {
-	let options = '';
-	for ( const [ code, option ] of BOOLEAN_CONFIGURATION_OPTIONS ) {
-		if ( store.state[ option ] ) {
-			options += code;
+function getExplicitHtmlOptions() {
+	let htmlOptions = '';
+	for ( const [
+		enabledCode,
+		disabledCode,
+		option,
+	] of BOOLEAN_CONFIGURATION_OPTIONS ) {
+		const override = booleanConfigurationOverrides[ option ];
+		if ( override === true ) {
+			htmlOptions += enabledCode;
+		} else if ( override === false ) {
+			htmlOptions += disabledCode;
 		}
 	}
-	return options;
+	return htmlOptions;
+}
+
+/** @returns {string} */
+function getResolvedHtmlOptions() {
+	let htmlOptions = '';
+	for ( const [
+		enabledCode,
+		disabledCode,
+		option,
+	] of BOOLEAN_CONFIGURATION_OPTIONS ) {
+		if ( store.state[ option ] ) {
+			htmlOptions += enabledCode;
+		} else {
+			htmlOptions += disabledCode;
+		}
+	}
+	return htmlOptions;
 }
 
 /** @param {BooleanConfigurationOption} stateKey */
@@ -852,6 +909,12 @@ function getToggleHandler( stateKey ) {
 		const isChecked = /** @type {HTMLInputElement} */ ( e.target ).checked;
 
 		store.state[ stateKey ] = isChecked;
+		booleanConfigurationOverrides[ stateKey ] = isChecked;
+		if ( isChecked ) {
+			localStorage.setItem( `${ NS }-${ stateKey }`, '1' );
+		} else {
+			localStorage.removeItem( `${ NS }-${ stateKey }` );
+		}
 		store.watchURL();
 	};
 }

--- a/html-api-debugger/main.mjs
+++ b/html-api-debugger/main.mjs
@@ -535,28 +535,22 @@ const store = createStore( NS, {
 	watchURL() {
 		const u = new URL( document.location.href );
 		let shouldReplace = false;
-		for ( const [ param, prop ] of /** @type {const} */ ( [
-			[ 'html', 'html' ],
-			[ 'contextHTML', 'contextHTMLForUse' ],
-			[ 'selector', 'selector' ],
+		for ( const [ param, getValue ] of /** @type {const} */ ( [
+			[ 'html', () => store.state.html ],
+			[ 'contextHTML', () => store.state.contextHTMLForUse ],
+			[ 'selector', () => store.state.selector ],
+			[ HTML_OPTIONS_PARAM, getExplicitHtmlOptions ],
 		] ) ) {
-			if ( store.state[ prop ] ) {
-				u.searchParams.set( param, store.state[ prop ] );
-				shouldReplace = true;
+			const value = getValue();
+			if ( value ) {
+				if ( u.searchParams.get( param ) !== value ) {
+					u.searchParams.set( param, value );
+					shouldReplace = true;
+				}
 			} else if ( u.searchParams.has( param ) ) {
 				u.searchParams.delete( param );
 				shouldReplace = true;
 			}
-		}
-		const htmlOptions = getExplicitHtmlOptions();
-		if ( htmlOptions ) {
-			if ( u.searchParams.get( HTML_OPTIONS_PARAM ) !== htmlOptions ) {
-				u.searchParams.set( HTML_OPTIONS_PARAM, htmlOptions );
-				shouldReplace = true;
-			}
-		} else if ( u.searchParams.has( HTML_OPTIONS_PARAM ) ) {
-			u.searchParams.delete( HTML_OPTIONS_PARAM );
-			shouldReplace = true;
 		}
 		if ( shouldReplace ) {
 			history.replaceState( null, '', u );
@@ -864,18 +858,21 @@ function getStoredBooleanConfigurationValue( option ) {
 	return Boolean( localStorage.getItem( `${ NS }-${ option }` ) );
 }
 
-/** @returns {string} */
-function getExplicitHtmlOptions() {
+/**
+ * @param {( option: BooleanConfigurationOption ) => boolean|null} getValue
+ * @returns {string}
+ */
+function buildHtmlOptions( getValue ) {
 	let htmlOptions = '';
 	for ( const [
 		enabledCode,
 		disabledCode,
 		option,
 	] of BOOLEAN_CONFIGURATION_OPTIONS ) {
-		const override = booleanConfigurationOverrides[ option ];
-		if ( override === true ) {
+		const value = getValue( option );
+		if ( value === true ) {
 			htmlOptions += enabledCode;
-		} else if ( override === false ) {
+		} else if ( value === false ) {
 			htmlOptions += disabledCode;
 		}
 	}
@@ -883,20 +880,15 @@ function getExplicitHtmlOptions() {
 }
 
 /** @returns {string} */
+function getExplicitHtmlOptions() {
+	return buildHtmlOptions(
+		( option ) => booleanConfigurationOverrides[ option ],
+	);
+}
+
+/** @returns {string} */
 function getResolvedHtmlOptions() {
-	let htmlOptions = '';
-	for ( const [
-		enabledCode,
-		disabledCode,
-		option,
-	] of BOOLEAN_CONFIGURATION_OPTIONS ) {
-		if ( store.state[ option ] ) {
-			htmlOptions += enabledCode;
-		} else {
-			htmlOptions += disabledCode;
-		}
-	}
-	return htmlOptions;
+	return buildHtmlOptions( ( option ) => Boolean( store.state[ option ] ) );
 }
 
 /** @param {BooleanConfigurationOption} stateKey */

--- a/html-api-debugger/main.mjs
+++ b/html-api-debugger/main.mjs
@@ -547,6 +547,12 @@ const store = createStore( NS, {
 				shouldReplace = true;
 			}
 		}
+		for ( const [ , option ] of BOOLEAN_CONFIGURATION_OPTIONS ) {
+			if ( u.searchParams.has( option ) ) {
+				u.searchParams.delete( option );
+				shouldReplace = true;
+			}
+		}
 		const options = getEnabledOptions();
 		if ( options ) {
 			if ( u.searchParams.get( 'options' ) !== options ) {

--- a/html-api-debugger/main.mjs
+++ b/html-api-debugger/main.mjs
@@ -547,12 +547,6 @@ const store = createStore( NS, {
 				shouldReplace = true;
 			}
 		}
-		for ( const [ , option ] of BOOLEAN_CONFIGURATION_OPTIONS ) {
-			if ( u.searchParams.has( option ) ) {
-				u.searchParams.delete( option );
-				shouldReplace = true;
-			}
-		}
 		const options = getEnabledOptions();
 		if ( options ) {
 			if ( u.searchParams.get( 'options' ) !== options ) {

--- a/html-api-debugger/main.mjs
+++ b/html-api-debugger/main.mjs
@@ -68,6 +68,9 @@ let mutationObserver = null;
  * @property {'breadcrumbs'|'insertionMode'} hoverInfo
  *
  *
+ * @typedef {'showClosers'|'showInvisible'|'showVirtual'} BooleanConfigurationOption
+ *
+ *
  * @typedef  State
  * @property {ReadonlyArray<string>} treeWarnings
  * @property {string} selector
@@ -127,13 +130,19 @@ let mutationObserver = null;
 
 const createStore = /** @type {typeof I.store<Store>} */ ( I.store );
 
+const BOOLEAN_CONFIGURATION_OPTIONS = /** @type {const} */ ( [
+	[ 'C', 'showClosers' ],
+	[ 'I', 'showInvisible' ],
+	[ 'V', 'showVirtual' ],
+] );
+
 /** @type {Store} */
 const store = createStore( NS, {
 	// @ts-expect-error Server provided state is not included here.
 	state: {
-		showClosers: Boolean( localStorage.getItem( `${ NS }-showClosers` ) ),
-		showInvisible: Boolean( localStorage.getItem( `${ NS }-showInvisible` ) ),
-		showVirtual: Boolean( localStorage.getItem( `${ NS }-showVirtual` ) ),
+		showClosers: getInitialBooleanConfigurationValue( 'showClosers' ),
+		showInvisible: getInitialBooleanConfigurationValue( 'showInvisible' ),
+		showVirtual: getInitialBooleanConfigurationValue( 'showVirtual' ),
 
 		playbackPoint: null,
 		previewCorePrNumber: null,
@@ -272,6 +281,10 @@ const store = createStore( NS, {
 			}
 			if ( store.state.selector ) {
 				searchParams.set( 'selector', store.state.selector );
+			}
+			const options = getEnabledOptions();
+			if ( options ) {
+				searchParams.set( 'options', options );
 			}
 			const base = '/wp-admin/admin.php';
 			const u = new URL(
@@ -534,6 +547,16 @@ const store = createStore( NS, {
 				shouldReplace = true;
 			}
 		}
+		const options = getEnabledOptions();
+		if ( options ) {
+			if ( u.searchParams.get( 'options' ) !== options ) {
+				u.searchParams.set( 'options', options );
+				shouldReplace = true;
+			}
+		} else if ( u.searchParams.has( 'options' ) ) {
+			u.searchParams.delete( 'options' );
+			shouldReplace = true;
+		}
 		if ( shouldReplace ) {
 			history.replaceState( null, '', u );
 		}
@@ -791,22 +814,44 @@ const store = createStore( NS, {
 	},
 } );
 
-/** @param {keyof State} stateKey */
+/**
+ * @param {BooleanConfigurationOption} option
+ * @returns {boolean}
+ */
+function getInitialBooleanConfigurationValue( option ) {
+	const options = new URL( document.location.href ).searchParams.get(
+		'options',
+	);
+	if ( ! options ) {
+		return false;
+	}
+	return BOOLEAN_CONFIGURATION_OPTIONS.some(
+		( [ code, optionName ] ) =>
+			optionName === option && options.includes( code ),
+	);
+}
+
+/** @returns {string} */
+function getEnabledOptions() {
+	let options = '';
+	for ( const [ code, option ] of BOOLEAN_CONFIGURATION_OPTIONS ) {
+		if ( store.state[ option ] ) {
+			options += code;
+		}
+	}
+	return options;
+}
+
+/** @param {BooleanConfigurationOption} stateKey */
 function getToggleHandler( stateKey ) {
 	/**
 	 * @param {Event} e
 	 * @returns {void}
 	 */
 	return ( e ) => {
-		// @ts-expect-error
-		if ( e.target.checked ) {
-			// @ts-expect-error
-			store.state[ stateKey ] = true;
-			localStorage.setItem( `${ NS }-${ stateKey }`, '1' );
-		} else {
-			// @ts-expect-error
-			store.state[ stateKey ] = false;
-			localStorage.removeItem( `${ NS }-${ stateKey }` );
-		}
+		const isChecked = /** @type {HTMLInputElement} */ ( e.target ).checked;
+
+		store.state[ stateKey ] = isChecked;
+		store.watchURL();
 	};
 }

--- a/html-api-debugger/readme.txt
+++ b/html-api-debugger/readme.txt
@@ -15,6 +15,7 @@ Please file issues and pull requests on the [GitHub repository](https://github.c
 
 == Changelog ==
 
+* Preserve HTML tree visibility options in shared URLs.
 * Add "HTML5 Body" context button to allow setting default context.
 * Fix fragment tree depth so nodes following atomic elements (`textarea`, `script`, `style`) nest correctly to match the DOM tree.
 


### PR DESCRIPTION
## Summary

Adds compact URL state for debugger display options so copied URLs and Playground links can preserve option settings from issue #4.

The new `html-opts` query parameter supports per-option overrides:

- `C` / `c` for show closers on/off
- `I` / `i` for show invisible on/off
- `V` / `v` for show virtual on/off

Absent letters fall back to saved local preferences, and an absent `html-opts` parameter leaves all three options preference-driven. Shareable Playground links serialize all three resolved values for portability.

## Validation

- `npx tsc --noEmit`
- `npx biome check html-api-debugger/main.mjs`
- `git diff --check origin/main...HEAD`

Fixes #4